### PR TITLE
Added RNBO_MAX_NO_CREATE_MIN_WRAPPER flags

### DIFF
--- a/external/rnbo_external_wrapper/rnbo_external_wrapper.cpp
+++ b/external/rnbo_external_wrapper/rnbo_external_wrapper.cpp
@@ -1314,10 +1314,12 @@ class rnbo_external_wrapper :
 		RNBO::CoreObject mRNBOObj;
 };
 
+#ifndef RNBO_MAX_NO_CREATE_MIN_WRAPPER
 #ifndef RNBO_WRAPPER_MAX_NAME
 #error(you must define RNBO_WRAPPER_MAX_NAME)
 #else
 //expand tokens before calling MIN_EXTERNAL_CUSTOM
 #define XMIN_EXTERNAL_CUSTOM(a, b) MIN_EXTERNAL_CUSTOM(a, b)
 XMIN_EXTERNAL_CUSTOM(rnbo_external_wrapper, RNBO_WRAPPER_MAX_NAME);
+#endif
 #endif


### PR DESCRIPTION
I added a RNBO_MAX_NO_CREATE_MIN_WRAPPER flag around the parts in the rnbo_external_wrapper, that instantiate the external instance, so the wrapper classes can be used in 3rd party projects as well, that instantiate their own min external instance