### PR TITLE
enable -ffast_math for externals

### DIFF
--- a/external/rnbo_external_wrapper/CMakeLists.txt
+++ b/external/rnbo_external_wrapper/CMakeLists.txt
@@ -61,3 +61,13 @@ if (BUILD_SYSTEM_IS_MINGW)
 		-static-libstdc++
 	)
 endif()
+
+if (MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		$<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:/fp:fast>
+	)
+else()
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		$<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:-ffast-math>
+	)
+endif()


### PR DESCRIPTION
same as the JIT compilation does in Max (rnbo~)